### PR TITLE
Hotfix/dataset yolo

### DIFF
--- a/ikomia/dnn/dataset.py
+++ b/ikomia/dnn/dataset.py
@@ -242,7 +242,7 @@ def load_yolo_dataset(folder_path: str, class_path: str) -> dict:
     category_names = {}
     categories = read_class_names(class_path)
 
-    for i in enumerate(categories):
+    for i in range(len(categories)):
         category_names[i] = categories[i]
 
     data["metadata"] = {"category_names": category_names}

--- a/ikomia/dnn/dataset.py
+++ b/ikomia/dnn/dataset.py
@@ -417,7 +417,7 @@ def load_pascalvoc_dataset(annotation_folder: str, img_folder: str, instance_seg
     categories = read_class_names(class_path)
     category_ids = {}
 
-    for i in enumerate(categories):
+    for i in range(len(categories)):
         category_ids[categories[i]] = i
 
     if annotation_folder != img_folder:
@@ -478,7 +478,7 @@ def load_pascalvoc_dataset(annotation_folder: str, img_folder: str, instance_seg
             data["images"].append(img_data)
 
     category_names = {}
-    for i in enumerate(categories):
+    for i in range(len(categories)):
         category_names[i] = categories[i]
 
     data["metadata"] = {"category_names": category_names}


### PR DESCRIPTION
Fix category names initialization using dataset yolo and pascal voc. Fixing the following error

```Python
File ~/virtual_envs/venvyolov10/lib/python3.10/site-packages/ikomia/dataprocess/workflow.py:435, in Workflow.run(self)
    432 run_mode = self._get_run_mode()
    434 if run_mode == Workflow.RunMode.SINGLE:
--> 435     super().run()
    436     metrics = self.get_time_metrics()
    437     total_time = metrics['total_time']

RuntimeError: <class 'TypeError'>: list indices must be integers or slices, not tuple:   File "/home/jupyter/Ikomia/Plugins/Python/dataset_yolo/dataset_yolo_process.py", line 65, in run
    output.data = dataset.load_yolo_dataset(param.dataset_folder, param.class_file)

  File "/home/jupyter/virtual_envs/venvyolov10/lib/python3.10/site-packages/ikomia/dnn/dataset.py", line 246, in load_yolo_dataset
    category_names[i] = categories[i]
 (Code 18)
```